### PR TITLE
Updated DateMixin

### DIFF
--- a/coops-ui/src/mixins/date-mixin.ts
+++ b/coops-ui/src/mixins/date-mixin.ts
@@ -53,12 +53,13 @@ export default class DateMixin extends Vue {
   }
 
   /**
-   * Formats a simple date string (YYYY-MM-DD) to (Weekday, Month, Day, Year) for readability.
+   * Formats a simple date string (YYYY-MM-DD) to (Month Day, Year) for readability.
    *
    * @param date The date string to format.
    * @returns The re-formatted date string without the day name.
    */
   toReadableDate (date: string): string {
-    return (new Date(date).toDateString().split(' ').slice(1).join(' '))
+    const regex = / (?!.* )/
+    return (new Date(date).toDateString().split(' ').slice(1).join(' ').replace(regex, ', '))
   }
 }

--- a/coops-ui/tests/unit/ARDate.spec.ts
+++ b/coops-ui/tests/unit/ARDate.spec.ts
@@ -27,9 +27,10 @@ describe('AnnualReport - Part 1 - UI', () => {
   it('succeeds when the Annual report date outputs are correct', () => {
     const wrapper = shallowMount(ARDate, { store })
     const vm: any = wrapper.vm
-    const today = new Date().toDateString().split(' ').slice(1).join(' ')
+    const regex = / (?!.* )/
+    const today = new Date().toDateString().split(' ').slice(1).join(' ').replace(regex, ', ')
 
-    expect(vm.$el.querySelector('.ar-date').textContent).toContain('Sep 18 2020')
+    expect(vm.$el.querySelector('.ar-date').textContent).toContain('Sep 18, 2020')
     expect(vm.$el.querySelector('.file-date').textContent).toContain(`Today (${today})`)
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* /freshworksstudio/lear

*Description of changes:*

* Updated dateMixin method to input a comma between the day and year values in the date output. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
